### PR TITLE
feat: Add drag and drop and fix multiple bugs

### DIFF
--- a/iso_logic.py
+++ b/iso_logic.py
@@ -413,8 +413,10 @@ class ISOBuilder:
 
     def _write_data_block(self, data):
         lba = self.next_lba
-        self._write_data_at_lba(lba, data)
-        self.next_lba += math.ceil(len(data) / self.logical_block_size) if data else 1
+        num_blocks = math.ceil(len(data) / self.logical_block_size) if data else 1
+        padded_data = data.ljust(num_blocks * self.logical_block_size, b'\x00')
+        self._write_data_at_lba(lba, padded_data)
+        self.next_lba += num_blocks
         return lba
 
     def _get_short_name(self, name):


### PR DESCRIPTION
This commit introduces drag and drop functionality and fixes several critical bugs related to loading and saving ISO files.

- **Drag and Drop:** Users can now drag and drop files and folders from their operating system onto the application to add them to the ISO. A new `DroppableTreeWidget` class was created to handle the drag and drop events.
- **Bug Fixes:**
  - Fixed a `KeyError: 'extent_location'` that occurred when loading an ISO.
  - Fixed a `KeyError: 'date'` that occurred when loading an ISO.
  - Fixed an `AttributeError` that occurred when saving an ISO by ensuring the root directory's parent is set to itself.
  - Fixed a `MemoryError` that occurred when saving an ISO by preventing an infinite loop in the `get_node_path` function.
  - Fixed a `struct.error` that occurred when saving an ISO by correcting the format string in `_generate_path_tables`.
  - Fixed a bug that caused the content of existing files to be omitted when saving an ISO, resulting in a very small file size.
  - Fixed an ISO corruption issue by ensuring all data written to the ISO is padded to fill a complete sector.